### PR TITLE
New Feature Patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ ENV app_dir="/app/Rebuild-DNDC" \
     rdndc_logo="https://raw.githubusercontent.com/elmerfdz/unRAIDscripts/master/Rebuild-DNDC/img/rdndc-logo.png" \
     discord_username="Rebuild-DNDC" \
     pf_loc=/app/pf \
-    TZ=
+    TZ= \
+    cont_list= 
 
 # Add local files
 COPY Rebuild-DNDC/ /app/Rebuild-DNDC

--- a/Rebuild-DNDC/Rebuild-DNDC.sh
+++ b/Rebuild-DNDC/Rebuild-DNDC.sh
@@ -107,24 +107,24 @@ inscope_container_vars()
     do
         pull_contnet_ids=($(docker inspect ${get_container_names[$a]} --format="{{ .HostConfig.NetworkMode }}" | sed -e 's/container://g'))
         pull_allmastercont_ids=($(<$mastercontepfile_loc/allmastercontepid.tmp))
-        echo ${#pull_allmastercont_ids[@]}
-        am=0
         while true
         do
-            if [ "$pull_contnet_ids" == "$mastercontid" ] || [ "$pull_contnet_ids" == "$pull_allmastercont_ids[$am]" ]
-            then
-                list_inscope_cont_tmpl+=($(find $docker_tmpl_loc -type f -iname "*-${get_container_names[$a]}.xml"))
-                list_inscope_cont_ids+=(${get_container_ids[$a]})
-                list_inscope_contnames+=(${get_container_names[$a]})     
-                no=${#list_inscope_contnames[@]}
-                echo "$no ${get_container_names[$a]}"
-                echo "- ContainerID ${get_container_ids[$a]}"       
-                echo "- NetworkID: $pull_contnet_ids"              
-                echo "- Template Location: ${list_inscope_cont_tmpl[$b]}"; b=$((b + 1))       
-                echo   
-                break
-            fi 
-            am=$((am+1))
+            for ((u=0; u < "${#pull_allmastercont_ids[@]}"; u++)) 
+            do  
+                if [ "$pull_contnet_ids" == "${pull_allmastercont_ids[$u]}" ]
+                then
+                    list_inscope_cont_tmpl+=($(find $docker_tmpl_loc -type f -iname "*-${get_container_names[$a]}.xml"))
+                    list_inscope_cont_ids+=(${get_container_ids[$a]})
+                    list_inscope_contnames+=(${get_container_names[$a]})     
+                    no=${#list_inscope_contnames[@]}
+                    echo "$no ${get_container_names[$a]}"
+                    echo "- ContainerID ${get_container_ids[$a]}"       
+                    echo "- NetworkID: $pull_contnet_ids"              
+                    echo "- Template Location: ${list_inscope_cont_tmpl[$b]}"; b=$((b + 1))       
+                    echo   
+                fi 
+            done    
+            break
         done    
     done
    

--- a/Rebuild-DNDC/Rebuild-DNDC.sh
+++ b/Rebuild-DNDC/Rebuild-DNDC.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #Rebuild-DNDC
 #author: https://github.com/elmerfdz
-ver=3.8.5-u
+ver=3.8.6-u
 
 #NON-CONFIGURABLE VARS
 contname=''
@@ -59,11 +59,11 @@ recreatecont_notify()
 #MAIN CODE
 first_run()
 {
-    if [ ! -d "$mastercontepfile_loc" ] || [ ! -e "$mastercontepfile_loc/mastercontepid.tmp" ] || [ ! -e "$mastercontepfile_loc/allmastercontepid.tmp" ] || [ ! -e "$mastercontepfile_loc/list_inscope_cont_ids.tmp" ] || [ ! -e "$mastercontepfile_loc/list_inscope_cont_tmpl.tmp" ] || [ ! -e "$mastercontepfile_loc/list_inscope_cont_names.tmp" ]  
+    if [ ! -d "$mastercontepfile_loc" ] || [ ! -e "$mastercontepfile_loc/mastercontepid.tmp" ] || [ ! -e "$mastercontepfile_loc/allmastercontid.tmp" ] || [ ! -e "$mastercontepfile_loc/list_inscope_cont_ids.tmp" ] || [ ! -e "$mastercontepfile_loc/list_inscope_cont_tmpl.tmp" ] || [ ! -e "$mastercontepfile_loc/list_inscope_cont_names.tmp" ]  
     then
         mkdir -p "$mastercontepfile_loc" && touch "$mastercontepfile_loc/mastercontepid.tmp" && touch "$mastercontepfile_loc/list_inscope_cont_ids.tmp" && touch "$mastercontepfile_loc/list_inscope_cont_tmpl.tmp" && touch "$mastercontepfile_loc/list_inscope_cont_names.tmp"
         echo "$getmastercontendpointid" > $mastercontepfile_loc/mastercontepid.tmp
-        echo "$mastercontid" > $mastercontepfile_loc/allmastercontepid.tmp
+        echo "$mastercontid" > $mastercontepfile_loc/allmastercontid.tmp
         echo "A. FIRST-RUN: SETUP COMPLETE"
         if [ "$unraid_notifications" == "yes" ]
         then              
@@ -106,7 +106,7 @@ inscope_container_vars()
     for ((a=0; a < "${#get_container_names[@]}"; a++)) 
     do
         pull_contnet_ids=($(docker inspect ${get_container_names[$a]} --format="{{ .HostConfig.NetworkMode }}" | sed -e 's/container://g'))
-        pull_allmastercont_ids=($(<$mastercontepfile_loc/allmastercontepid.tmp))
+        pull_allmastercont_ids=($(<$mastercontepfile_loc/allmastercontid.tmp))
         while true
         do
             for ((u=0; u < "${#pull_allmastercont_ids[@]}"; u++)) 
@@ -275,8 +275,8 @@ fi
 #Keep track of current & past master cotnainer IDs
 masteridpool_mod()
 {
-    echo "$getmastercontendpointid" >> $mastercontepfile_loc/allmastercontepid.tmp
-    tail -n $save_no_masterids allmastercontepid.tmp > allmastercontepid.tmp1 && mv allmastercontepid.tmp1 allmastercontepid.tmp
+    echo "$mastercontid" >> $mastercontepfile_loc/allmastercontid.tmp
+    tail -n $save_no_masterids allmastercontid.tmp > allmastercontid.tmp1 && mv allmastercontid.tmp1 allmastercontid.tmp
 }
 
 

--- a/Rebuild-DNDC/Rebuild-DNDC.sh
+++ b/Rebuild-DNDC/Rebuild-DNDC.sh
@@ -311,7 +311,7 @@ echo
 if [ "$was_rebuild" == 1 ]
 then 
     recreatecont_notify_complete
-    if [ "$was_run" == 1 ]
+    if [ "$was_run" == 0 ]
     then 
         masteridpool_mod
     fi

--- a/Rebuild-DNDC/Rebuild-DNDC.sh
+++ b/Rebuild-DNDC/Rebuild-DNDC.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #Rebuild-DNDC
 #author: https://github.com/elmerfdz
-ver=3.8.6-u
+ver=3.8.7-u
 
 #NON-CONFIGURABLE VARS
 contname=''
@@ -276,7 +276,7 @@ fi
 masteridpool_mod()
 {
     echo "$mastercontid" >> $mastercontepfile_loc/allmastercontid.tmp
-    tail -n $save_no_masterids allmastercontid.tmp > allmastercontid.tmp1 && mv allmastercontid.tmp1 allmastercontid.tmp
+    tail -n $save_no_masterids $mastercontepfile_loc/allmastercontid.tmp > $mastercontepfile_loc/allmastercontid.tmp1 && mv $mastercontepfile_loc/allmastercontid.tmp1 $mastercontepfile_loc/allmastercontid.tmp
 }
 
 
@@ -311,7 +311,10 @@ echo
 if [ "$was_rebuild" == 1 ]
 then 
     recreatecont_notify_complete
-    masteridpool_mod
+    if [ "$was_run" == 1 ]
+    then 
+        masteridpool_mod
+    fi
 fi
 echo 
 echo "------------------------------------------"

--- a/Rebuild-DNDC/Rebuild-DNDC.sh
+++ b/Rebuild-DNDC/Rebuild-DNDC.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #Rebuild-DNDC
 #author: https://github.com/elmerfdz
-ver=3.8.4-u
+ver=3.8.5-u
 
 #NON-CONFIGURABLE VARS
 contname=''

--- a/Rebuild-DNDC/Rebuild-DNDC.sh
+++ b/Rebuild-DNDC/Rebuild-DNDC.sh
@@ -59,10 +59,11 @@ recreatecont_notify()
 #MAIN CODE
 first_run()
 {
-    if [ ! -d "$mastercontepfile_loc" ] || [ ! -e "$mastercontepfile_loc/mastercontepid.tmp" ] || [ ! -e "$mastercontepfile_loc/list_inscope_cont_ids.tmp" ] || [ ! -e "$mastercontepfile_loc/list_inscope_cont_tmpl.tmp" ] || [ ! -e "$mastercontepfile_loc/list_inscope_cont_names.tmp" ]  
+    if [ ! -d "$mastercontepfile_loc" ] || [ ! -e "$mastercontepfile_loc/mastercontepid.tmp" ] || [ ! -e "$mastercontepfile_loc/allmastercontepid.tmp" ] || [ ! -e "$mastercontepfile_loc/list_inscope_cont_ids.tmp" ] || [ ! -e "$mastercontepfile_loc/list_inscope_cont_tmpl.tmp" ] || [ ! -e "$mastercontepfile_loc/list_inscope_cont_names.tmp" ]  
     then
         mkdir -p "$mastercontepfile_loc" && touch "$mastercontepfile_loc/mastercontepid.tmp" && touch "$mastercontepfile_loc/list_inscope_cont_ids.tmp" && touch "$mastercontepfile_loc/list_inscope_cont_tmpl.tmp" && touch "$mastercontepfile_loc/list_inscope_cont_names.tmp"
         echo "$getmastercontendpointid" > $mastercontepfile_loc/mastercontepid.tmp
+        echo "$mastercontid" > $mastercontepfile_loc/allmastercontepid.tmp
         echo "A. FIRST-RUN: SETUP COMPLETE"
         if [ "$unraid_notifications" == "yes" ]
         then              
@@ -106,9 +107,10 @@ inscope_container_vars()
     do
         pull_contnet_ids=($(docker inspect ${get_container_names[$a]} --format="{{ .HostConfig.NetworkMode }}" | sed -e 's/container://g'))
         pull_allmastercont_ids=($(<$mastercontepfile_loc/allmastercontepid.tmp))
+        echo ${#pull_allmastercont_ids[@]}
+        am=0
         while true
         do
-            am=0
             if [ "$pull_contnet_ids" == "$mastercontid" ] || [ "$pull_contnet_ids" == "$pull_allmastercont_ids[$am]" ]
             then
                 list_inscope_cont_tmpl+=($(find $docker_tmpl_loc -type f -iname "*-${get_container_names[$a]}.xml"))

--- a/Rebuild-DNDC/Rebuild-DNDC.sh
+++ b/Rebuild-DNDC/Rebuild-DNDC.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #Rebuild-DNDC
 #author: https://github.com/elmerfdz
-ver=3.8.7-u
+ver=3.8.8-u
 
 #NON-CONFIGURABLE VARS
 contname=''
@@ -275,8 +275,11 @@ fi
 #Keep track of current & past master cotnainer IDs
 masteridpool_mod()
 {
+if ! grep -Fxq "$mastercontid" $mastercontepfile_loc/allmastercontid.tmp
+then
     echo "$mastercontid" >> $mastercontepfile_loc/allmastercontid.tmp
     tail -n $save_no_masterids $mastercontepfile_loc/allmastercontid.tmp > $mastercontepfile_loc/allmastercontid.tmp1 && mv $mastercontepfile_loc/allmastercontid.tmp1 $mastercontepfile_loc/allmastercontid.tmp
+fi
 }
 
 

--- a/Rebuild-DNDC/Rebuild-DNDC.sh
+++ b/Rebuild-DNDC/Rebuild-DNDC.sh
@@ -263,6 +263,13 @@ then
 fi
 }
 
+#Keep track of current & past master cotnainer IDs
+masteridpool_mod()
+{
+    echo "$getmastercontendpointid" >> $mastercontepfile_loc/allmastercontepid.tmp
+    tail -n $save_no_masterids allmastercontepid.tmp > allmastercontepid.tmp1 && mv allmastercontepid.tmp1 allmastercontepid.tmp
+}
+
 
 echo
 echo "---------------------------------"
@@ -302,10 +309,3 @@ echo "------------------------------------------"
 echo " Run Completed: $datetime  "
 echo "------------------------------------------"
 echo
-
-
-masteridpool_mod()
-{
-    echo "$getmastercontendpointid" >> $mastercontepfile_loc/allmastercontepid.tmp
-    tail -n $save_no_masterids allmastercontepid.tmp > allmastercontepid.tmp1 && mv allmastercontepid.tmp1 allmastercontepid.tmp
-}

--- a/Rebuild-DNDC/Rebuild-DNDC.sh
+++ b/Rebuild-DNDC/Rebuild-DNDC.sh
@@ -105,18 +105,25 @@ inscope_container_vars()
     for ((a=0; a < "${#get_container_names[@]}"; a++)) 
     do
         pull_contnet_ids=($(docker inspect ${get_container_names[$a]} --format="{{ .HostConfig.NetworkMode }}" | sed -e 's/container://g'))
-        if [ "$pull_contnet_ids" == "$mastercontid" ]
-        then
-            list_inscope_cont_tmpl+=($(find $docker_tmpl_loc -type f -iname "*-${get_container_names[$a]}.xml"))
-            list_inscope_cont_ids+=(${get_container_ids[$a]})
-            list_inscope_contnames+=(${get_container_names[$a]})     
-            no=${#list_inscope_contnames[@]}
-            echo "$no ${get_container_names[$a]}"
-            echo "- ContainerID ${get_container_ids[$a]}"       
-            echo "- NetworkID: $pull_contnet_ids"              
-            echo "- Template Location: ${list_inscope_cont_tmpl[$b]}"; b=$((b + 1))       
-            echo   
-        fi 
+        pull_allmastercont_ids=($(<$mastercontepfile_loc/allmastercontepid.tmp))
+        while true
+        do
+            am=0
+            if [ "$pull_contnet_ids" == "$mastercontid" ] || [ "$pull_contnet_ids" == "$pull_allmastercont_ids[$am]" ]
+            then
+                list_inscope_cont_tmpl+=($(find $docker_tmpl_loc -type f -iname "*-${get_container_names[$a]}.xml"))
+                list_inscope_cont_ids+=(${get_container_ids[$a]})
+                list_inscope_contnames+=(${get_container_names[$a]})     
+                no=${#list_inscope_contnames[@]}
+                echo "$no ${get_container_names[$a]}"
+                echo "- ContainerID ${get_container_ids[$a]}"       
+                echo "- NetworkID: $pull_contnet_ids"              
+                echo "- Template Location: ${list_inscope_cont_tmpl[$b]}"; b=$((b + 1))       
+                echo   
+                break
+            fi 
+            am=$((am+1))
+        done    
     done
    
     if [ "${list_inscope_contnames}" == '' ]

--- a/Rebuild-DNDC/Rebuild-DNDC.sh
+++ b/Rebuild-DNDC/Rebuild-DNDC.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #Rebuild-DNDC
 #author: https://github.com/elmerfdz
-ver=3.8.3-u
+ver=3.8.4-u
 
 #NON-CONFIGURABLE VARS
 contname=''
@@ -295,10 +295,17 @@ echo
 if [ "$was_rebuild" == 1 ]
 then 
     recreatecont_notify_complete
-    #echo "$getmastercontendpointid" >> $mastercontepfile_loc/allmastercontepid.tmp
+    masteridpool_mod
 fi
 echo 
 echo "------------------------------------------"
 echo " Run Completed: $datetime  "
 echo "------------------------------------------"
 echo
+
+
+masteridpool_mod()
+{
+    echo "$getmastercontendpointid" >> $mastercontepfile_loc/allmastercontepid.tmp
+    tail -n $save_no_masterids allmastercontepid.tmp > allmastercontepid.tmp1 && mv allmastercontepid.tmp1 allmastercontepid.tmp
+}

--- a/root/etc/cont-init.d/30-install
+++ b/root/etc/cont-init.d/30-install
@@ -97,7 +97,16 @@ then
   echo "- Save no of master cotnainer IDs, default - 5"
   save_no_masterids='5'
 else
-  echo "- Ping IP alt set: $save_no_masterids"
+  echo "- Save no of master cotnainer IDs: $save_no_masterids"
+fi
+
+#[---------- Save number of master contaienr IDs----------]
+if [ -z "$cont_list" ]
+then
+  echo "- No containers set for manual run"
+  $cont_list='none'
+else
+  echo "- List of containers to build on manual run: $cont_list"
 fi
 
 #[---------- RUN AT STARTUP ----------]
@@ -116,8 +125,7 @@ then
   --username "$discord_username" \
   --avatar "$rdndc_logo" \
   --title "VARIABLES IN USE" \
-  --description "- Master Container Name:- $mastercontname\n- Master Cont Con Check:- $mastercontconcheck\n- Ping IP:- $ping_ip\n- Ping IP Alt:- $ping_ip_alt\n- Ping Count:- $ping_count\n- Sleep Seconds:- $sleep_secs\n- Cron Schedule:- $cron\n- Run at Startup:- $run_startup\n- Appdata Folder:- $mastercontepfile_loc\n- DockerTemplate Folder:- $docker_tmpl_loc\n- ParseDockerTemplate Script:- $rundockertemplate_script" \
-  --color "0x66ff33" \
+  --description "- Master Container Name:- $mastercontname\n- Master Cont Con Check:- $mastercontconcheck\n- Ping IP:- $ping_ip\n- Ping IP Alt:- $ping_ip_alt\n- Ping Count:- $ping_count\n- Sleep Seconds:- $sleep_secs\n- Cron Schedule:- $cron\n- Save no of Master Container IDs:- $save_no_masterids\n- Manual Run Container List:- $cont_list\n- Run at Startup:- $run_startup\n- Appdata Folder:- $mastercontepfile_loc\n- DockerTemplate Folder:- $docker_tmpl_loc\n- ParseDockerTemplate Script:- $rundockertemplate_script" \  --color "0x66ff33" \
   --author-icon "$rdndc_logo" \
   --footer-icon "$rdndc_logo"  &> /dev/null
   echo "- Pushed first notification to Discord"  

--- a/root/etc/cont-init.d/30-install
+++ b/root/etc/cont-init.d/30-install
@@ -91,6 +91,15 @@ else
   echo "- CRON schedule set: $cron"
 fi
 
+#[---------- Save number of master contaienr IDs----------]
+if [ -z "$save_no_masterids" ]
+then
+  echo "- Save no of master cotnainer IDs, default - 5"
+  save_no_masterids='5'
+else
+  echo "- Ping IP alt set: $save_no_masterids"
+fi
+
 #[---------- RUN AT STARTUP ----------]
 if [ "$run_startup" == "yes" ]
 then

--- a/root/etc/cont-init.d/30-install
+++ b/root/etc/cont-init.d/30-install
@@ -125,7 +125,8 @@ then
   --username "$discord_username" \
   --avatar "$rdndc_logo" \
   --title "VARIABLES IN USE" \
-  --description "- Master Container Name:- $mastercontname\n- Master Cont Con Check:- $mastercontconcheck\n- Ping IP:- $ping_ip\n- Ping IP Alt:- $ping_ip_alt\n- Ping Count:- $ping_count\n- Sleep Seconds:- $sleep_secs\n- Cron Schedule:- $cron\n- Save no of Master Container IDs:- $save_no_masterids\n- Manual Run Container List:- $cont_list\n- Run at Startup:- $run_startup\n- Appdata Folder:- $mastercontepfile_loc\n- DockerTemplate Folder:- $docker_tmpl_loc\n- ParseDockerTemplate Script:- $rundockertemplate_script" \  --color "0x66ff33" \
+  --description "- Master Container Name:- $mastercontname\n- Master Cont Con Check:- $mastercontconcheck\n- Ping IP:- $ping_ip\n- Ping IP Alt:- $ping_ip_alt\n- Ping Count:- $ping_count\n- Sleep Seconds:- $sleep_secs\n- Cron Schedule:- $cron\n- Save no of Master Container IDs:- $save_no_masterids\n- Manual Run Container List:- $cont_list\n- Run at Startup:- $run_startup\n- Appdata Folder:- $mastercontepfile_loc\n- DockerTemplate Folder:- $docker_tmpl_loc\n- ParseDockerTemplate Script:- $rundockertemplate_script" \
+  --color "0x66ff33" \
   --author-icon "$rdndc_logo" \
   --footer-icon "$rdndc_logo"  &> /dev/null
   echo "- Pushed first notification to Discord"  


### PR DESCRIPTION
Create master container ID pool

- by default store 5 master container IDs, which will help when master container starts multiple times but RDNDC hasn't got a chance to run since restarts to store in-scope container IDs.