### PR TITLE
Update ParseDockerTemplate.sh

### DIFF
--- a/Rebuild-DNDC/ParseDockerTemplate.sh
+++ b/Rebuild-DNDC/ParseDockerTemplate.sh
@@ -103,7 +103,12 @@ add_cpuset(){
 
 add_net(){
 	call_add_ports=0
-	net=$(xmllint --xpath "/Container/Networking/Mode/text()" $xmlFile 2> /dev/null)
+	nettest=$(xmllint --xpath "/Container/Networking/Mode/text()" $xmlFile 2> /dev/null)
+	if [ -z "$nettest" ]; then
+		net=$(xmllint --xpath "/Container/Network/text()" $xmlFile 2> /dev/null);
+	else
+		net=$(xmllint --xpath "/Container/Networking/Mode/text()" $xmlFile 2> /dev/null)
+	fi
 	docker_string+=" --net=\"$net\""
 	if [[ $net == bridge ]]; then
 		call_add_ports=1


### PR DESCRIPTION
From the UnRAID 6.10-RC2 Release Notes

webgui: Docker: Only save templates as v2

The added if statement fixes the issue with the new v2 templates while keeping backwards compatibility

Fixes Issue #56 