### PR TITLE
Support for custom networks

### DIFF
--- a/Rebuild-DNDC/Rebuild-DNDC.sh
+++ b/Rebuild-DNDC/Rebuild-DNDC.sh
@@ -37,7 +37,12 @@ templatename=''
 datetime=$(date)
 buildcont_cmd="$rundockertemplate_script -v $docker_tmpl_loc/my-$templatename.xml"
 mastercontid=$(docker inspect --format="{{.Id}}" $mastercontname)
-getmastercontendpointid=$(docker inspect $mastercontname --format="{{ .NetworkSettings.EndpointID }}")
+if [[ -z "$custom_network" || "$custom_network" = "false" ]]
+then
+    getmastercontendpointid=$(docker inspect $mastercontname --format="{{ .NetworkSettings.EndpointID }}")
+else
+    getmastercontendpointid=$(docker inspect $mastercontname --format="{{ .NetworkSettings.Networks.${custom_network}.EndpointID }}")
+fi
 get_container_names=($(docker ps -a --format="{{ .Names }}"))
 get_container_ids=($(docker ps -a --format="{{ .ID }}"))
 save_no_mcontids=${save_no_mcontids:-20}


### PR DESCRIPTION
Did I forget to actually make the PR?

For https://github.com/elmerfdz/rebuild-dndc/issues/61

Ran in to the same issues as mentioned, as I rely heavily on custom networks in my setup. Containers communicate by container names instead of through ports opened on host, routing most traffic through reverse proxy.

Checks value of environment variable `custom_network`, if length is zero or value is false, it runs the usual `docker inspect $mastercontname --format="{{ .NetworkSettings.EndpointID }}"`, else it runs `docker inspect $mastercontname --format="{{ .NetworkSettings.Networks.${custom_network}.EndpointID }}"`

I guess the unraid template should be updated accordingly as well.