### PR TITLE
check for none on add_net

### DIFF
--- a/Rebuild-DNDC/ParseDockerTemplate.sh
+++ b/Rebuild-DNDC/ParseDockerTemplate.sh
@@ -110,11 +110,13 @@ add_net(){
 	else
 		net=$(xmllint --xpath "/Container/Networking/Mode/text()" $xmlFile 2> /dev/null)
 	fi
-	docker_string+=" --net=\"$net\""
-	if [[ $net == bridge ]]; then
-		call_add_ports=1
+	if [[ $net != "none" ]]; then
+		docker_string+=" --net=\"$net\""
+		if [[ $net == bridge ]]; then
+			call_add_ports=1
+		fi
+		[ "$verbose" = "1" ] && echo "Found Net:  --net=\"$net\""
 	fi
-	[ "$verbose" = "1" ] && echo "Found Net:  --net=\"$net\""
 }
 
 add_privileged(){


### PR DESCRIPTION
Potential fix for https://github.com/elmerfdz/rebuild-dndc/issues/65

Previous logs
```
--Build qbittorrent

Name: qbittorrent
Found Net:  --net="none"
Found Environment:  -e PUID="99"
Found Environment:  -e PGID="100"
Found Environment:  -e UMASK="002"
Found TimeZone:  -e TZ="America/New_York"
Found volume:  -v "/mnt/user/appdata/qbittorrent":"/config":rw
Found volume:  -v "/mnt/user/data/torrents/":"/data/torrents/":rw
Found Extra params:  --net=container:gluetun
Found Repo:  cr.hotio.dev/hotio/qbittorrent:release
/usr/bin/docker run -d --name="qbittorrent" --net="none" -e PUID="99" -e PGID="100" -e UMASK="002" -e TZ="America/New_York" -v "/mnt/user/appdata/qbittorrent":"/config":rw -v "/mnt/user/data/torrents/":"/data/torrents/":rw --net=container:gluetun cr.hotio.dev/hotio/qbittorrent:release
/usr/bin/docker: Error response from daemon: Container cannot be connected to network endpoints: container:gluetun, none.
See '/usr/bin/docker run --help'.
Command was: /usr/bin/docker run -d --name="qbittorrent" --net="none" -e PUID="99" -e PGID="100" -e UMASK="002" -e TZ="America/New_York" -v "/mnt/user/appdata/qbittorrent":"/config":rw -v "/mnt/user/data/torrents/":"/data/torrents/":rw --net=container:gluetun cr.hotio.dev/hotio/qbittorrent:release
Note this script does not parse xml encoded strings correctly (like &#xF8;), which may cause docker to fail.

```
After: 
```
Name: qbittorrent
Found Environment:  -e PUID="99"
Found Environment:  -e PGID="100"
Found Environment:  -e UMASK="002"
Found TimeZone:  -e TZ="America/New_York"
Found volume:  -v "/mnt/user/appdata/qbittorrent":"/config":rw
Found volume:  -v "/mnt/user/data/torrents/":"/data/torrents/":rw
Found Extra params:  --net=container:gluetun
Found Repo:  cr.hotio.dev/hotio/qbittorrent:release
/usr/bin/docker run -d --name="qbittorrent" -e PUID="99" -e PGID="100" -e UMASK="002" -e TZ="America/New_York" -v "/mnt/user/appdata/qbittorrent":"/config":rw -v "/mnt/user/data/torrents/":"/data/torrents/":rw --net=container:gluetun cr.hotio.dev/hotio/qbittorrent:release
b013f1c28838bd9601335981b307711a186513187f6d00c1699a89b86fdd3400
```