### PR TITLE
Improve support for custom networks

### DIFF
--- a/Rebuild-DNDC/Rebuild-DNDC.sh
+++ b/Rebuild-DNDC/Rebuild-DNDC.sh
@@ -134,7 +134,12 @@ first_run()
     then
         printf "A. SKIPPING: FIRST RUN SETUP\n" 
         was_run=0
-        getmastercontendpointid=$(docker inspect $mastercontname --format="{{ .NetworkSettings.EndpointID }}")
+        if [[ -z "$custom_network" || "$custom_network" = "false" ]]
+        then
+            getmastercontendpointid=$(docker inspect $mastercontname --format="{{ .NetworkSettings.EndpointID }}")
+        else
+            getmastercontendpointid=$(docker inspect $mastercontname --format="{{ .NetworkSettings.Networks.${custom_network}.EndpointID }}")
+        fi
         currentendpointid=$(<$mastercontepfile_loc/mastercontepid.tmp)      
     fi
 }


### PR DESCRIPTION
Follow-up to address a lingering issue related to https://github.com/elmerfds/rebuild-dndc/issues/61

The fix included in https://github.com/elmerfds/rebuild-dndc/pull/63 enabled support for custom Docker networks on startup, but did not address the same issue on subsequent runs after the first one.

This is a quick patch to fix that and enable custom network support on all runs!